### PR TITLE
Update methodName file for lib/test-to-trx.js

### DIFF
--- a/lib/test-to-trx.js
+++ b/lib/test-to-trx.js
@@ -41,7 +41,7 @@ function testToTrx(test, computerName, cwd, options) {
         test: new UnitTest({
             name: test.fullTitle(),
             methodCodeBase: test.file ? path.relative(safeCwd, test.file) : 'none',
-            methodName: 'none',
+            methodName: test.fullTitle(),
             methodClassName: 'none',
         }),
         computerName,


### PR DESCRIPTION
Fix method shows identical name when retrieving test results using cypress